### PR TITLE
add ruby tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
     name: Lint ERB
     uses: ./.github/workflows/linterb.yml
 
+  test-ruby:
+    name: Test Ruby
+    uses: ./.github/workflows/minitest.yml
+
   test-javascript:
     name: Test JavaScript
     uses: alphagov/govuk-infrastructure/.github/workflows/jasmine.yml@main

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -1,0 +1,19 @@
+name: Run Minitest
+
+on: workflow_call
+
+jobs:
+  run-erb-lint:
+    name: Run Minitest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run Minitest
+        run: bundle exec rake test


### PR DESCRIPTION

Ruby tests were missing from CI workflow. 
Additionally the test step is needed to pass CI check and merge branches