### PR TITLE
Add `data-ga4-filter-parent` to `select`

### DIFF
--- a/app/views/components/_select_with_search.html.erb
+++ b/app/views/components/_select_with_search.html.erb
@@ -31,6 +31,6 @@
   <% if multiple %>
     <%= hidden_field_tag name, nil %>
   <% end %>
-  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, "data-ga4-document-type": ga_data[:document_type], "data-ga4-section": ga_data[:section], "data-ga4-change-category": ga_data[:change_category] %>
+  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, "data-ga4-document-type": ga_data[:document_type], "data-ga4-section": ga_data[:section], "data-ga4-change-category": ga_data[:change_category], "data-ga4-filter-parent": ga_data[:filter_parent] %>
 
 <% end %>


### PR DESCRIPTION
## What

Adds `data-ga4-filter-parent` to `select` if specified in `ga_data`.

## Why

Required data attribute for `Ga4FinderTracker`.
