### PR TITLE
Remove `ga4-select-with-search-tracker`

### DIFF
--- a/app/assets/javascripts/select_with_search_component/application.js
+++ b/app/assets/javascripts/select_with_search_component/application.js
@@ -1,2 +1,1 @@
 //= require ./components/select-with-search
-//= require ./analytics-modules/ga4-select-with-search-tracker


### PR DESCRIPTION
## What

Remove `//= require ./analytics-modules/ga4-select-with-search-tracker` from `application.js`

## Why

If the application using select_with_search_component does not include `ga4-select-with-search-tracker.js` then the application will error. We are planning to remove this file from `whitehall` but it also means that if this component is used in another application that doesn't have include this file then it will error.
